### PR TITLE
Fix flikker

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -15,6 +15,5 @@
         {{ $slot }}
 
         @livewireScripts
-        <script src="https://kit.fontawesome.com/179125d0a6.js" crossorigin="anonymous"></script>
     </body>
 </html>

--- a/resources/views/livewire/operators.blade.php
+++ b/resources/views/livewire/operators.blade.php
@@ -1,40 +1,39 @@
 <div>
-    @persist('header')
-        <header
-            class="flex text-sm py-8 px-8 border-php-violet/50 border-b bg-php-violet-light dark:bg-php-gray-dark z-10 transition-all dark:border-php-gray md:border-b-0 md:py-0 md:h-24 md:fixed md:w-full md:top-0"
-            :class="{ 'header-collapse': navAtTop }"
-            x-data="{ navAtTop: false }"
-            @scroll.window="navAtTop = (window.pageYOffset < 96) ? false: true"
-        >
-            <div class="container flex flex-col items-center gap-6 max-w-4xl mx-auto md:flex-row md:gap-10">
-                <a href="/" class="w-full max-w-44 md:max-w-56 active:translate-y-px">
-                    <x-logo></x-logo>
-                    <h1 class="sr-only">PHP Operators</h1>
-                </a>
-                <div class="relative h-12 w-full">
-                    <input
-                        wire:model.live.debounce="search"
-                        class="bg-php-violet rounded-full px-6 w-full h-full focus:ring-2 ring-inset ring-php-purple/15 outline-none placeholder:text-php-purple-dark/50 dark:bg-php-gray-light dark:placeholder:text-white/50 dark:ring-php-purple/50"
-                        type="text" placeholder="Find out more about a PHP operator" />
-                    @if($search)
-                        <button
-                            class="absolute top-0 right-0 px-6 h-full flex items-center text-lg text-php-purple-dark hover:text-php-purple active:translate-y-px dark:text-white dark:hover:text-white/50"
-                            wire:click="setSearch('')"
-                        >
-                            <span class="pointer-events-none fa-duotone fa-xmark-large"></span>
-                        </button>
-                    @else
-                        <button
-                            class="absolute top-0 right-0 px-6 h-full flex items-center text-lg text-php-purple-dark hover:text-php-purple active:translate-y-px dark:text-white dark:hover:text-white/50"
-                            wire:click="random"
-                        >
-                            <span class="pointer-events-none fa-duotone fa-shuffle"></span>
-                        </button>
-                    @endif
-                </div>
+    <header
+        class="flex text-sm py-8 px-8 border-php-violet/50 border-b bg-php-violet-light dark:bg-php-gray-dark z-10 transition-all dark:border-php-gray md:border-b-0 md:py-0 md:h-24 md:fixed md:w-full md:top-0"
+        :class="{ 'header-collapse': navAtTop }"
+        x-data="{ navAtTop: false }"
+        @scroll.window="navAtTop = (window.pageYOffset < 96) ? false: true"
+    >
+        <div class="container flex flex-col items-center gap-6 max-w-4xl mx-auto md:flex-row md:gap-10">
+            <a href="/" class="w-full max-w-44 md:max-w-56 active:translate-y-px">
+                <x-logo></x-logo>
+                <h1 class="sr-only">PHP Operators</h1>
+            </a>
+            <div class="relative h-12 w-full">
+                <input
+                    wire:model.live.debounce="search"
+                    class="bg-php-violet rounded-full px-6 w-full h-full focus:ring-2 ring-inset ring-php-purple/15 outline-none placeholder:text-php-purple-dark/50 dark:bg-php-gray-light dark:placeholder:text-white/50 dark:ring-php-purple/50"
+                    type="text" placeholder="Find out more about a PHP operator" />
+                @if($search)
+                    <button
+                        class="absolute top-0 right-0 px-6 h-full flex items-center text-lg text-php-purple-dark hover:text-php-purple active:translate-y-px dark:text-white dark:hover:text-white/50"
+                        wire:click="setSearch('')"
+                    >
+                        <span class="pointer-events-none fa-duotone fa-xmark-large"></span>
+                    </button>
+                @else
+                    <button
+                        class="absolute top-0 right-0 px-6 h-full flex items-center text-lg text-php-purple-dark hover:text-php-purple active:translate-y-px dark:text-white dark:hover:text-white/50"
+                        wire:click="random"
+                    >
+                        <span class="pointer-events-none fa-duotone fa-shuffle"></span>
+                    </button>
+                @endif
             </div>
-        </header>
-    @endpersist
+        </div>
+    </header>
+
     <main class="main">
         @foreach ($operatorsByCategory as $category => $operators)
             <section class="max-w-4xl mx-auto px-12 my-12 first:mt-36">
@@ -122,3 +121,7 @@
         </div>
     </footer>
 </div>
+
+@assets
+<script src="https://kit.fontawesome.com/179125d0a6.js" crossorigin="anonymous"></script>
+@endassets


### PR DESCRIPTION
Dit zou het flikkeren van de header moeten oplossen. Het is iets vreemd en de oplossing is niet echt schaalbaar:

Ik merkte dat het niet de hele header was die flikkerde maar het icon rechts.
In mijn netwerk tab zag ik dat bij elke navigatie fontawesome opnieuw ingeladen werd, wat de flikker van het icoon veroorzaakte.
Nu FA ingeladen wordt in de @asset directive is er geen probleem meer. Jammer genoeg kan je die directive enkel in een component gebruiken, wat niet ideaal is, maar in dit specifieke geval eigenlijk geen probleem.

Ik vermoed dat FA misschien iets funky doet in hun script want dit is de eerste keer dat ik zo iets merk.