### PR TITLE
Fixed binary numbers in result comment

### DIFF
--- a/resources/content/bitwise-03-binary-xor.md
+++ b/resources/content/bitwise-03-binary-xor.md
@@ -14,8 +14,8 @@ $b = 0b01;
 $c = 0b10;
 $d = 0b11;
 
-var_dump($a ^ $b); // 0b01, 0
+var_dump($a ^ $b); // 0b00, 0
 var_dump($b ^ $c); // 0b11, 3
-var_dump($a ^ $d); // 0b11, 2
-var_dump($c ^ $d); // 0b11, 1
+var_dump($a ^ $d); // 0b10, 2
+var_dump($c ^ $d); // 0b01, 1
 ```


### PR DESCRIPTION
- Updated comments to reflect the actual results:
  - $a ^ $b → 0b00, 0 instead of 0b01, 0
  - $a ^ $d → 0b10, 2 instead of 0b11, 2
  - $c ^ $d → 0b01, 1 instead of 0b11, 1