### PR TITLE
Fix less-than and greater-than operator examples

### DIFF
--- a/resources/content/comparison-06-less-than.md
+++ b/resources/content/comparison-06-less-than.md
@@ -10,6 +10,6 @@ Check if the value to the left is less than the value to the right.
 
 ```php
 2 < 3;   // true
-2 < '3'; // false
-2 < 3.0; // false
+2 < '3'; // true
+2 < 3.0; // true
 ```

--- a/resources/content/comparison-07-greater-than.md
+++ b/resources/content/comparison-07-greater-than.md
@@ -10,6 +10,6 @@ Check if the value to the left is greater than the value to the right.
 
 ```php
 3 > 2;   // true
-2 > '2'; // false
-2 > 2.0; // false
+3 > '2'; // true
+3 > 2.0; // true
 ```


### PR DESCRIPTION
## Summary
- Fixed incorrect less-than examples: `2 < '3'` and `2 < 3.0` both return `true` (PHP converts the string/float for comparison), not `false` as shown
- Improved greater-than examples to use `3 > '2'` and `3 > 2.0` (both `true`) instead of comparing equal values, which better demonstrates cross-type comparisons

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)